### PR TITLE
Add Homebrew formula bump workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
     environment:
       name: main
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -189,3 +189,22 @@ jobs:
           draft: false
           prerelease: ${{ needs.prerelease.outputs.value }}
           token: ${{ secrets.PAT }}
+
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    needs:
+      - package
+      - checksum
+      - prerelease
+    if: startsWith(github.ref, 'refs/tags/') && needs.prerelease.outputs.value == 'false'
+
+    environment:
+      name: main
+
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: infat
+        env:
+          COMMITTER_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
Adds CI job to bump the Homebrew formula when a new (non prerelease) release is published.

This should be merged after there is an Infat formula merged in to Homebrew core.

See #13