### PR TITLE
README.md: infat is now in Homebrew proper

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ infat --verbose info --ext pdf
 ### Homebrew
 
 ```bash
-brew install philocalyst/tap/infat
+brew install infat
 ```
 
 ### From Source


### PR DESCRIPTION
I just saw this:

```
> brew update && brew upgrade
==> Updating Homebrew...
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
infat
⋮
```