### PR TITLE
recursive search for apps

### DIFF
--- a/infat-lib/src/macos/workspace.rs
+++ b/infat-lib/src/macos/workspace.rs
@@ -144,7 +144,7 @@ pub fn find_applications() -> Result<Vec<PathBuf>> {
     let mut apps = Vec::new();
 
     while search_paths.len() > 0 {
-	let path = search_paths.pop().unwrap();
+        let path = search_paths.pop().unwrap();
         if !path.exists() {
             debug!("Skipping non-existent path: {}", path.to_str().unwrap());
             continue;


### PR DESCRIPTION
This was necessary because home-manager now copies the apps, and this prevents infat from finding applications in ~/Applications/Home Manager Apps and instead would throw an error about the application being set. Running with -v confirmed that the inside of the Home Manager Apps folder wasn't being checked